### PR TITLE
Add iframe-based record management demo

### DIFF
--- a/form.html
+++ b/form.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Record Form</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    label { display: block; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <h1 id="form-title"></h1>
+  <form id="recordForm">
+    <label id="idLabel">
+      ID: <input type="text" id="id" name="id" readonly />
+    </label>
+    <label>
+      Name: <input type="text" id="name" name="name" required />
+    </label>
+    <button type="submit">Save</button>
+  </form>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const idInput = document.getElementById('id');
+    const nameInput = document.getElementById('name');
+    const idLabel = document.getElementById('idLabel');
+    const title = document.getElementById('form-title');
+    let mode = 'add';
+    if (params.has('id')) {
+      mode = 'edit';
+      idInput.value = params.get('id');
+      nameInput.value = params.get('name') || '';
+      title.textContent = 'Edit Record';
+    } else {
+      idLabel.style.display = 'none';
+      title.textContent = 'Add Record';
+    }
+    document.getElementById('recordForm').addEventListener('submit', e => {
+      e.preventDefault();
+      const record = { id: idInput.value, name: nameInput.value };
+      window.parent.postMessage({ type: 'saveRecord', mode, record }, '*');
+      const url = window.location.pathname + window.location.search;
+      window.parent.closeTab(url);
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,20 @@
       const lastTab = tabsDiv.querySelector('.tab:last-child');
       if (lastTab) switchTab(lastTab.dataset.url);
     }
+
+    // Expose functions for child iframes
+    window.openTab = openTab;
+    window.closeTab = closeTab;
+
+    // Forward messages between iframes
+    window.addEventListener('message', e => {
+      if (e.data && e.data.type === 'saveRecord') {
+        const searchFrame = document.querySelector('#iframe-container iframe[data-url^="search-results.html"]');
+        if (searchFrame && searchFrame.contentWindow) {
+          searchFrame.contentWindow.postMessage(e.data, '*');
+        }
+      }
+    });
   </script>
 </body>
 </html>

--- a/search-results.html
+++ b/search-results.html
@@ -7,6 +7,8 @@
     body { font-family: Arial, sans-serif; padding: 20px; }
     label { display: block; margin-bottom: 8px; }
     #result { margin-top: 20px; }
+    table { border-collapse: collapse; margin-top: 10px; }
+    th, td { border: 1px solid #ccc; padding: 4px 8px; }
   </style>
 </head>
 <body>
@@ -19,6 +21,13 @@
     <button type="submit">Search</button>
   </form>
   <div id="result"></div>
+  <button id="add">Add</button>
+  <table id="results">
+    <thead>
+      <tr><th>ID</th><th>Name</th><th>Actions</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <script>
     const params = new URLSearchParams(window.location.search);
     const q = params.get('q') || '';
@@ -27,6 +36,55 @@
     if (q) {
       resultDiv.textContent = `Showing results for "${q}"`;
     }
+
+    const data = Array.from({ length: 10 }, (_, i) => ({ id: i + 1, name: `Item ${i + 1}` }));
+    const tbody = document.querySelector('#results tbody');
+
+    function renderTable() {
+      tbody.innerHTML = '';
+      data.forEach(record => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${record.id}</td><td>${record.name}</td>` +
+          `<td><button class="edit" data-id="${record.id}">Edit</button>` +
+          `<button class="delete" data-id="${record.id}">Delete</button></td>`;
+        tbody.appendChild(tr);
+      });
+    }
+    renderTable();
+
+    document.getElementById('add').addEventListener('click', () => {
+      window.parent.openTab('form.html', 'Add Record');
+    });
+
+    document.getElementById('results').addEventListener('click', e => {
+      if (e.target.classList.contains('edit')) {
+        const id = e.target.dataset.id;
+        const record = data.find(r => r.id == id);
+        window.parent.openTab(`form.html?id=${record.id}&name=${encodeURIComponent(record.name)}`, 'Edit Record');
+      }
+      if (e.target.classList.contains('delete')) {
+        const id = e.target.dataset.id;
+        const index = data.findIndex(r => r.id == id);
+        if (index > -1) {
+          data.splice(index, 1);
+          renderTable();
+        }
+      }
+    });
+
+    window.addEventListener('message', e => {
+      if (e.data && e.data.type === 'saveRecord') {
+        const { mode, record } = e.data;
+        if (mode === 'add') {
+          record.id = data.length ? Math.max(...data.map(r => r.id)) + 1 : 1;
+          data.push(record);
+        } else if (mode === 'edit') {
+          const idx = data.findIndex(r => r.id == record.id);
+          if (idx > -1) data[idx] = record;
+        }
+        renderTable();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Display search results in a table with 10 mock records and action buttons
- Demonstrate adding, editing, and deleting records via iframe-based form
- Forward messages through the main iframe container to keep views in sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bbd048ac83269259416b627e6981