### PR TITLE
Ensure record form tab closes after save

### DIFF
--- a/form.html
+++ b/form.html
@@ -39,7 +39,8 @@
       e.preventDefault();
       const record = { id: idInput.value, name: nameInput.value };
       window.parent.postMessage({ type: 'saveRecord', mode, record }, '*');
-      const url = window.location.pathname + window.location.search;
+      const path = window.location.pathname.split('/').pop();
+      const url = path + window.location.search;
       window.parent.closeTab(url);
     });
   </script>


### PR DESCRIPTION
## Summary
- Close add/edit record tab using relative URL so it matches the tab key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d810f7e48326a9d05fc24edff3d7