### PR TITLE
Fix blank search tab after adding record

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,9 @@
       iframe.addEventListener('load', () => {
         try {
           const path = iframe.contentWindow.location.pathname.split('/').pop();
-          iframe.dataset.url = path + iframe.contentWindow.location.search;
+          const fullUrl = path + iframe.contentWindow.location.search;
+          iframe.dataset.url = fullUrl;
+          tab.dataset.url = fullUrl;
         } catch (e) {
           // Ignore cross-origin frames
         }


### PR DESCRIPTION
## Summary
- sync tab's URL with iframe on load to keep active tab after internal navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d957d8a083268e87d5543cadf73f