### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/form.html
+++ b/form.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Record Form</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>

--- a/hello.html
+++ b/hello.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Hello Page</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>

--- a/index.html
+++ b/index.html
@@ -2,11 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Iframe Demo</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body { margin: 0; }
-    #iframe-container { width: 100%; height: calc(100vh - 80px); }
+    body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+    #menu { flex-wrap: wrap; }
+    #tabs { flex-shrink: 0; }
+    #iframe-container { flex: 1; width: 100%; }
     iframe { width: 100%; height: 100%; border: none; display: none; }
     iframe.active { display: block; }
     #tabs .nav-link { position: relative; }

--- a/search-results.html
+++ b/search-results.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Search Results</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
@@ -16,12 +17,14 @@
   </form>
   <div id="result" class="mb-3"></div>
   <button id="add" class="btn btn-success mb-3">Add</button>
-  <table id="results" class="table table-striped">
-    <thead>
-      <tr><th>ID</th><th>Name</th><th>Actions</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <div class="table-responsive">
+    <table id="results" class="table table-striped">
+      <thead>
+        <tr><th>ID</th><th>Name</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
   <script>
     const params = new URLSearchParams(window.location.search);
     const q = params.get('q') || '';

--- a/search.html
+++ b/search.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Search Demo</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag and flex-based layout so iframe demo scales to mobile
- wrap search results table in Bootstrap's responsive container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dc16e17c8326802a11bb98310765